### PR TITLE
Add regression test for comment handling with event ID (#1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>cloud.prefab</groupId>
   <artifactId>sse-handler</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/src/test/java/cloud/prefab/sse/SSEHandlerTest.java
+++ b/src/test/java/cloud/prefab/sse/SSEHandlerTest.java
@@ -151,6 +151,24 @@ class SSEHandlerTest {
       );
   }
 
+  @Test
+  void itHandlesCommentsWhenEventIdIsPresent() throws InterruptedException {
+    submissionPublisher.submit("id: 12345\n");
+    submissionPublisher.submit(": this is a comment\n");
+    submissionPublisher.submit("data: hello\n");
+    submissionPublisher.submit("\n");
+    await()
+      .atMost(3, TimeUnit.SECONDS)
+      .untilAsserted(() ->
+        assertThat(endSubscriber.events)
+          .hasSize(2)
+          .containsExactly(
+            new CommentEvent("this is a comment"),
+            new DataEvent("message", "hello\n", "12345")
+          )
+      );
+  }
+
   private static class EndSubscriber implements Flow.Subscriber<Event> {
 
     private static final Logger LOG = LoggerFactory.getLogger(EndSubscriber.class);


### PR DESCRIPTION
## Summary
- Add regression test to verify comments work properly when event IDs are present in SSE stream
- Version bump to 1.0.1 for release

## Problem
The r3labs/sse client had a bug where comments were not properly handled when event IDs were present in the stream (https://github.com/r3labs/sse/issues/163). This PR adds a regression test to ensure our SSE client doesn't have this issue.

## Solution
- Added `itHandlesCommentsWhenEventIdIsPresent()` test that verifies both comment and data events are emitted correctly when an ID is present
- Our implementation correctly processes comments immediately per line, independent of event ID processing
- Version bumped to 1.0.1 to ship this verification

## Test plan
- [x] New test passes
- [x] All existing tests continue to pass
- [x] Verified comment handling is independent of event ID state

🤖 Generated with [Claude Code](https://claude.ai/code)