### PR TITLE
Add modern Maven Central publishing workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,22 @@
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 11
+      uses: actions/setup-java@v4
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: maven
+    - name: Run tests with Maven
+      run: mvn clean verify

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,4 +19,4 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Run tests with Maven
-      run: mvn clean verify
+      run: mvn clean verify --no-transfer-progress

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,93 @@
+name: Publish to Maven Central
+
+on:
+  workflow_run:
+    workflows: ["Java CI with Maven"]
+    types:
+      - completed
+    branches: [ "main" ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: github.repository == 'prefab-cloud/java-simple-sse-client' && github.event.workflow_run.conclusion == 'success'
+
+    steps:
+    - name: "Checkout"
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v4
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: maven
+
+    - name: Extract version from pom.xml
+      id: extract_version
+      run: |
+        VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "Current version: $VERSION"
+
+    - name: Check if version exists in Maven Central
+      id: version_check
+      run: |
+        VERSION=${{ steps.extract_version.outputs.version }}
+        echo "Checking if version $VERSION exists in Maven Central..."
+
+        # Check if version exists (non-snapshot versions only)
+        if [[ "$VERSION" != *-SNAPSHOT ]]; then
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://repo1.maven.org/maven2/cloud/prefab/sse-handler/$VERSION/sse-handler-$VERSION.pom")
+          if [ "$HTTP_STATUS" = "200" ]; then
+            echo "Version $VERSION already exists in Maven Central"
+            echo "should_publish=false" >> $GITHUB_OUTPUT
+          else
+            echo "Version $VERSION does not exist in Maven Central"
+            echo "should_publish=true" >> $GITHUB_OUTPUT
+          fi
+        else
+          echo "Snapshot version detected, skipping publication"
+          echo "should_publish=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Import GPG key
+      if: steps.version_check.outputs.should_publish == 'true'
+      uses: crazy-max/ghaction-import-gpg@v6
+      with:
+        gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+        passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+    - name: Configure Maven settings
+      if: steps.version_check.outputs.should_publish == 'true'
+      uses: s4u/maven-settings-action@v3.0.0
+      with:
+        servers: |
+          [
+            {
+              "id": "central",
+              "username": "${{ secrets.MAVEN_CENTRAL_USERNAME }}",
+              "password": "${{ secrets.MAVEN_CENTRAL_TOKEN }}"
+            }
+          ]
+
+    - name: Publish to Maven Central
+      if: steps.version_check.outputs.should_publish == 'true'
+      env:
+        GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      run: |
+        echo "Publishing version ${{ steps.extract_version.outputs.version }} to Maven Central..."
+        mvn clean deploy -P release --no-transfer-progress -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }}
+
+    - name: Create GitHub Release
+      if: steps.version_check.outputs.should_publish == 'true'
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: v${{ steps.extract_version.outputs.version }}
+        name: Release v${{ steps.extract_version.outputs.version }}
+        generate_release_notes: true
+        prerelease: ${{ contains(steps.extract_version.outputs.version, 'RC') || contains(steps.extract_version.outputs.version, 'beta') || contains(steps.extract_version.outputs.version, 'alpha') }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -13,9 +13,13 @@
   <version>1.0.1</version>
   <packaging>jar</packaging>
 
+  <name>Prefab SSE Handler</name>
+  <description>A simple Server-Sent Events (SSE) client handler for Java applications</description>
+
   <properties>
     <basepom.check.skip-license>true</basepom.check.skip-license>
     <basepom.check.skip-spotbugs>true</basepom.check.skip-spotbugs>
+    <basepom.nexus-staging.skip>true</basepom.nexus-staging.skip>
     <dep.assertj.version>3.23.1</dep.assertj.version>
     <dep.awaitability.version>4.2.0</dep.awaitability.version>
     <dep.junit.version>5.9.1</dep.junit.version>
@@ -115,13 +119,20 @@
           </executions>
         </plugin>
         <plugin>
+          <groupId>org.sonatype.central</groupId>
+          <artifactId>central-publishing-maven-plugin</artifactId>
+          <version>0.8.0</version>
+          <configuration>
+            <publishingServerId>central</publishingServerId>
+            <autoPublish>true</autoPublish>
+          </configuration>
+        </plugin>
+        <plugin>
           <groupId>org.sonatype.plugins</groupId>
           <artifactId>nexus-staging-maven-plugin</artifactId>
           <version>1.6.13</version>
           <configuration>
-            <serverId>sonatype-nexus-staging</serverId>
-            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+            <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
           </configuration>
         </plugin>
         <plugin>
@@ -160,8 +171,8 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
         <extensions>true</extensions>
       </plugin>
     </plugins>
@@ -191,14 +202,4 @@
     <developerConnection>scm:git:git@github.com:prefab-cloud/java-simple-sse-client.git</developerConnection>
     <url>https://github.com/prefab-cloud/java-simple-sse-client</url>
   </scm>
-  <distributionManagement>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-  </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -157,20 +157,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>3.0.1</version>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-            <phase>verify</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.sonatype.central</groupId>
         <artifactId>central-publishing-maven-plugin</artifactId>
         <extensions>true</extensions>
@@ -202,4 +188,28 @@
     <developerConnection>scm:git:git@github.com:prefab-cloud/java-simple-sse-client.git</developerConnection>
     <url>https://github.com/prefab-cloud/java-simple-sse-client</url>
   </scm>
+
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.0.1</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <phase>verify</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
## Summary
- Replace nexus-staging-maven-plugin with central-publishing-maven-plugin
- Add GitHub Actions workflows for CI and publishing to Maven Central
- Update pom.xml configuration for modern Central Portal publishing

## Changes
- **CI Workflow**: `maven.yml` runs tests on push/PR to main
- **Publishing Workflow**: `publish.yml` publishes to Maven Central after CI success
- **POM Updates**: Modern central-publishing-maven-plugin configuration with auto-publish
- **Nexus Override**: Added `basepom.nexus-staging.skip=true` to disable legacy behavior

## Features
- Only publishes non-snapshot versions
- Checks if version already exists before publishing
- Automatic GPG signing with GitHub secrets
- Creates GitHub releases with auto-generated notes
- Uses modern Maven Central publishing process

## Required Setup
✅ GitHub secrets are configured:
- `GPG_PRIVATE_KEY`
- `GPG_PASSPHRASE` 
- `MAVEN_CENTRAL_USERNAME`
- `MAVEN_CENTRAL_TOKEN`

## Test Plan
- [x] Maven build works with new configuration (`mvn clean verify`)
- [x] All existing tests pass
- [x] Workflows are properly configured for cloud.prefab namespace
- [ ] Test publish workflow after merge (will trigger on next version change)

🤖 Generated with [Claude Code](https://claude.ai/code)