### PR TITLE
Fix publishing workflow version extraction timeout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Extract version from pom.xml
       id: extract_version
       run: |
-        VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+        VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
         echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "Current version: $VERSION"
 


### PR DESCRIPTION
## Problem
The publishing workflow was hanging for 54+ seconds (and sometimes timing out) due to the problematic version extraction command:

```bash
mvn help:evaluate -Dexpression=project.version -q -DforceStdout
```

The `-q` and `-DforceStdout` flags conflict, causing Maven to suppress the output it's waiting for.

## Solution
Replace with the fast, reliable Maven exec approach:

```bash
mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec
```

## Benefits
- ⚡ **Faster**: ~1.1s instead of 54+ seconds
- 🔄 **Reliable**: No hanging or timeouts  
- 🏗️ **Maven-native**: Properly handles properties and inheritance
- ✅ **Tested**: Confirmed working locally

## Test Results
```bash
$ time mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec
1.0.1
real    0m1.109s
```

🤖 Generated with [Claude Code](https://claude.ai/code)